### PR TITLE
Fix typo: 'paticipants' -> 'participants' in fetch_stats.py

### DIFF
--- a/fetch_stats.py
+++ b/fetch_stats.py
@@ -573,7 +573,7 @@ def process_hackathon(hackathon_config, token, org_repos_cache=None):
         # Track which PRs we just fetched reviews for, so we don't duplicate them
         newly_fetched_pr_urls = {pr["html_url"] for pr in prs_to_fetch_reviews}
         
-        # Extract reviews from existing leaderboard/paticipants
+        # Extract reviews from existing leaderboard/participants
         seen_review_ids = {r["id"] for r in all_reviews if r.get("id")}
         
         for p in old_participants:


### PR DESCRIPTION
## Summary

- Fixed a spelling mistake in a comment in `fetch_stats.py` line 576
- `paticipants` → `participants` (missing letter 'r')

Closes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal documentation improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->