### PR TITLE
Fix broken links in SETUP.md: BLT-Hackathon -> BLT-Hackathons

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -198,7 +198,7 @@ Once deployed, share your hackathon dashboard:
 ## Need Help?
 
 - 📖 Read the full [README](README.md)
-- 💬 Check [Discussions](https://github.com/OWASP-BLT/BLT-Hackathon/discussions)
-- 🐛 Report issues on [GitHub Issues](https://github.com/OWASP-BLT/BLT-Hackathon/issues)
+- 💬 Check [Discussions](https://github.com/OWASP-BLT/BLT-Hackathons/discussions)
+- 🐛 Report issues on [GitHub Issues](https://github.com/OWASP-BLT/BLT-Hackathons/issues)
 
 Happy hacking! 🚀


### PR DESCRIPTION
## Summary

Fixed two broken links in the **Need Help?** section of `SETUP.md`. The links pointed to `BLT-Hackathon` (singular) which is the wrong repository name — causing 404 errors for users who click them.

- `BLT-Hackathon/discussions` → `BLT-Hackathons/discussions`
- `BLT-Hackathon/issues` → `BLT-Hackathons/issues`

Closes #76

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated external support links in setup documentation to reference the correct support resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->