### PR TITLE
Remove debug traceback code left in exception handler in fetch_stats.py

### DIFF
--- a/fetch_stats.py
+++ b/fetch_stats.py
@@ -768,9 +768,6 @@ def main():
                 logger.info("✅ Saved summary for '%s' to %s", slug, summary_path)
         except Exception as exc:
             logger.error("❌ Failed to process hackathon %s: %s", slug, exc)
-            import traceback
-
-            traceback.print_exc()
 
     # Update the top-level stats.json with basic summary info
     primary = hackathons[0] if hackathons else {}

--- a/fetch_stats.py
+++ b/fetch_stats.py
@@ -767,7 +767,7 @@ def main():
                     json.dump(build_summary(data), f, indent=2)
                 logger.info("✅ Saved summary for '%s' to %s", slug, summary_path)
         except Exception as exc:
-            logger.error("❌ Failed to process hackathon %s: %s", slug, exc)
+            logger.exception("❌ Failed to process hackathon %s: %s", slug, exc)
 
     # Update the top-level stats.json with basic summary info
     primary = hackathons[0] if hackathons else {}


### PR DESCRIPTION
## Summary

Removed leftover debug code (`import traceback` + `traceback.print_exc()`) from the exception handler in `fetch_stats.py`.

The `logger.error()` call already captures the error information. The `traceback.print_exc()` was debug code that:
- Uses an `import` inside a function body (code smell)
- Bypasses the logging system by printing directly to stdout
- Produces duplicate/noisy output in production runs

Closes #78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved error logging mechanism to automatically capture detailed exception information during error handling, providing enhanced context for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->