### PR TITLE
More mentors included

### DIFF
--- a/hackathon-participants/blt-mentor-warmup.yml
+++ b/hackathon-participants/blt-mentor-warmup.yml
@@ -15,7 +15,6 @@ participants:
   - Vaswani2003
   - kittenbytes
   - Captain-T2004
-  - elsheikh21
   - Kunal1522
   - RudraBhaskar9439
   - dev-sanidhya

--- a/hackathon-participants/blt-mentor-warmup.yml
+++ b/hackathon-participants/blt-mentor-warmup.yml
@@ -15,7 +15,7 @@ participants:
   - Vaswani2003
   - kittenbytes
   - Captain-T2004
-  - elsheik21
+  - elsheikh21
   - Kunal1522
   - RudraBhaskar9439
   - dev-sanidhya
@@ -25,3 +25,8 @@ participants:
   - btwshivam
   - ramansh18
   - Ankitsinghsisodya
+  - nipunnegi2
+  - Tanish1408
+  - gojo-satorou-v7
+  - AadiSharma49
+  - Ayushd785

--- a/hackathon-participants/blt-mentor-warmup.yml
+++ b/hackathon-participants/blt-mentor-warmup.yml
@@ -30,3 +30,7 @@ participants:
   - gojo-satorou-v7
   - AadiSharma49
   - Ayushd785
+  - HanilJain
+  - manikandanchandran
+  - CodeWithBishal
+  - rahulnegi20


### PR DESCRIPTION
Added missing mentors. If someone is missing, please share their GitHub username and add them to BLT-Pool, as the current list includes all 23 mentors from BLT-Pool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Removed one participant from the hackathon participants list
  * Added nine new participants to the hackathon participants list
<!-- end of auto-generated comment: release notes by coderabbit.ai -->